### PR TITLE
Update repo add script

### DIFF
--- a/repo/repo_add.sh
+++ b/repo/repo_add.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Проверка на наличие прав root
 if [[ $EUID != 0 ]]; then
@@ -6,11 +7,20 @@ if [[ $EUID != 0 ]]; then
     exit 1
 fi
 
-echo "Enter the paths to the containers separated by space:"
+if ! command -v dnf >/dev/null; then
+    echo "dnf command not found" >&2
+    exit 1
+fi
 
-# Чтение ввода пользователя и преобразование в массив
-read -a paths
+# Allow repo paths via positional parameters or prompt the user
+if [[ $# -gt 0 ]]; then
+    paths=("$@")
+else
+    echo "Enter the paths to the containers separated by space:"
+    read -a paths
+fi
 
+# Список путей может быть получен через аргументы или интерактивный ввод
 # Проверка, что введен хотя бы один путь
 if [[ ${#paths[@]} -eq 0 ]]; then
     echo "At least one path must be entered!"
@@ -20,11 +30,10 @@ fi
 # Цикл по всем введенным путям
 for path in "${paths[@]}"; do
     echo "Adding repo: $path"
-    dnf config-manager --add-repo $path
+    if ! dnf config-manager --add-repo "$path"; then
+        echo "Failed to add repo: $path" >&2
+        exit 1
+    fi
 done
-
-
-
-#dnf makecache
-
-#dnf check-update
+dnf makecache
+dnf check-update


### PR DESCRIPTION
## Summary
- improve the `repo_add.sh` helper
  - enable bash strict mode and verify `dnf` is available
  - allow repo paths via arguments or interactive input
  - quote paths and check `config-manager` results
  - refresh cache and list updates after adding repos

## Testing
- `bash -n repo/repo_add.sh`

------
https://chatgpt.com/codex/tasks/task_e_6870edd6807c8323b499c9f73b84de1b